### PR TITLE
add jest support

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,9 @@ var makeWebpackConfig = require('./webpack/makeconfig')
 var webpackBuild = require('./webpack/build')
 var webpackDevServer = require('./webpack/devserver')
 var yargs = require('yargs')
+var jest = require('jest-cli')
+var harmonize = require('harmonize')
+harmonize()
 
 var args = yargs
   .alias('p', 'production')
@@ -18,8 +21,24 @@ gulp.task('build-webpack', (args.production ? webpackBuild : webpackDevServer)
 
 gulp.task('build', ['build-webpack'])
 
-// TODO: Add Jest and es6lint and more.
+// TODO: Add es6lint and more.
 gulp.task('test', webpackBuild(makeWebpackConfig(false)))
+
+gulp.task('jest', function() {
+  var rootDir = './src',
+    successHandler = function (success) {
+      process.on('exit', function(){
+        process.exit(success ? 0 : 1)
+      })
+    }
+
+  jest.runCLI({config: {
+    'rootDir': rootDir,
+    'scriptPreprocessor': '../node_modules/babel-jest',
+    'testFileExtensions': ['es6', 'js'],
+    'moduleFileExtensions': ['js', 'json', 'es6']
+  }}, rootDir, successHandler)
+})
 
 gulp.task('server', ['env', 'build'], bg('node', 'src/server'))
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "babel": "^4.0.1",
     "babel-core": "^4.0.1",
+    "babel-jest": "^4.0.0",
     "babel-loader": "^4.0.0",
     "bluebird": "^2.9.9",
     "classnames": "^1.1.4",
@@ -30,8 +31,10 @@
     "gulp": "^3.8.10",
     "gulp-bg": "0.0.5",
     "gulp-util": "^3.0.2",
+    "harmonize": "^1.4.1",
     "immutable": "^3.6.4",
     "intl": "^0.1.4",
+    "jest-cli": "^0.4.0",
     "less-loader": "^2.0.0",
     "node-notifier": "^4.1.0",
     "normalize.css": "^3.0.2",

--- a/src/__tests__/getrandomstring.js
+++ b/src/__tests__/getrandomstring.js
@@ -1,0 +1,9 @@
+// __tests__/foo.js
+
+jest.dontMock('../lib/getrandomstring')
+import {getRandomString} from '../lib/getrandomstring'
+
+describe('getRandomString', () => {
+  it('is a string', () =>
+    expect(getRandomString()).toEqual(jasmine.any(String)))
+})


### PR DESCRIPTION
adds a gulp target: `gulp jest` which runs any jest tests found in `src/__tests__`

see previously https://github.com/steida/este-todomvc/pull/8