### PR TITLE
webpack: styleLoaders fix

### DIFF
--- a/webpack/makeconfig.js
+++ b/webpack/makeconfig.js
@@ -18,7 +18,7 @@ module.exports = function(isDevelopment) {
 
   function stylesLoaders() {
     return Object.keys(loaders).map(function(ext) {
-      var prefix = 'css-loader!autoprefixer-loader?browsers=last 2 version!stylus-loader'
+      var prefix = 'css-loader!autoprefixer-loader?browsers=last 2 version'
       var extLoaders = prefix + loaders[ext]
       var loader = isDevelopment
         ? 'style-loader!' + extLoaders


### PR DESCRIPTION
stylus-loader is concrete loader, not a prefix