### PR TITLE
webpack: configure for use with CDN

### DIFF
--- a/src/server/express.js
+++ b/src/server/express.js
@@ -12,9 +12,7 @@ export default function() {
   app.use(compression())
   // TODO: Add favicon.
   // app.use(favicon('assets/img/favicon.ico'))
-  // TODO: Move to CDN.
   app.use('/build', express.static('build'))
-  app.use('/assets', express.static('assets'))
 
   app.get('*', (req, res) => {
     const acceptsLanguages = req.acceptsLanguages(config.appLocales)

--- a/webpack/build.js
+++ b/webpack/build.js
@@ -4,6 +4,8 @@
 
 var webpack = require('webpack')
 var gutil = require('gulp-util')
+var fs = require('fs');
+var path = require('path')
 
 module.exports = function(webpackConfig) {
   return function(callback) {
@@ -14,6 +16,13 @@ module.exports = function(webpackConfig) {
       if (buildError) {
         throw new gutil.PluginError('webpack', buildError)
       }
+
+      var outputFilename = path.join(__dirname, 'stats.json');
+      fs.writeFile(outputFilename, JSON.stringify(jsonStats, null, 4), function(err) {
+        if(err) {
+          gutil.log('[webpack]', err);
+        }
+      })
 
       gutil.log('[webpack]', stats.toString({
         colors: true,

--- a/webpack/makeconfig.js
+++ b/webpack/makeconfig.js
@@ -76,7 +76,7 @@ module.exports = function(isDevelopment) {
     },
     output: isDevelopment ? {
       path: path.join(__dirname, '/build/'),
-      filename: '[name]-[hash].js',
+      filename: '[name].js',
       publicPath: 'http://localhost:8888/build/'
     } : {
       path: 'build/',

--- a/webpack/makeconfig.js
+++ b/webpack/makeconfig.js
@@ -62,7 +62,7 @@ module.exports = function(isDevelopment) {
     },
     module: {
       loaders: [{
-        loader: 'url-loader?limit=100000',
+        loader: 'url-loader?limit=10000&name=[name]-[hash].[ext]',
         test: /\.(gif|jpg|png|woff|woff2|eot|ttf|svg)$/
       }, {
         exclude: /node_modules/,
@@ -76,11 +76,12 @@ module.exports = function(isDevelopment) {
     },
     output: isDevelopment ? {
       path: path.join(__dirname, '/build/'),
-      filename: '[name].js',
+      filename: '[name]-[hash].js',
       publicPath: 'http://localhost:8888/build/'
     } : {
       path: 'build/',
-      filename: '[name].js'
+      filename: '[name]-[hash].js',
+      publicPath: 'https://ab4s6a3e2pfi5.cloudfront.net/'
     },
     plugins: (function() {
       var plugins = [
@@ -102,7 +103,7 @@ module.exports = function(isDevelopment) {
         plugins.push(
           // Render styles into separate cacheable file to prevent FOUC and
           // optimize for critical rendering path.
-          new ExtractTextPlugin('app.css', {
+          new ExtractTextPlugin('[name]-[contenthash].css', {
             allChunks: true
           }),
           new webpack.optimize.DedupePlugin(),


### PR DESCRIPTION
Started work on compatibility with a CDN here.

- [x] Use hashes instead of version numbers for long lived assets
- [ ] Configure `render.js` to read from `stats.json` so that we can get the hash while in production.
- [ ] Allow CDN path to be configurable. Open to how you want this to be done.
- [ ] Documentation about the above and about setting up your CDN as a reverse proxy for /build.