### PR TITLE
only load google analytics in production

### DIFF
--- a/src/server/render.js
+++ b/src/server/render.js
@@ -70,7 +70,7 @@ function getPageHtml(Handler, appState) {
       })();
     </script>`
 
-  if (config.googleAnalyticsId !== 'UA-XXXXXXX-X')
+  if (config.isProduction && config.googleAnalyticsId !== 'UA-XXXXXXX-X')
     scriptHtml += `
       <script>
         (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=


### PR DESCRIPTION
You probably want to load GA only for production even. This is to prevent loading it when you set your GA id in `config.js`.