### PR TITLE
Fixed broken test.

### DIFF
--- a/src/lib/__tests__/getrandomstring.js
+++ b/src/lib/__tests__/getrandomstring.js
@@ -1,8 +1,8 @@
-// jest.dontMock('../getrandomstring');
-// import {getRandomString} from '../getrandomstring';
+jest.dontMock('../getrandomstring');
+const getRandomString = require('../getrandomstring').getRandomString;
 
-// describe('getRandomString', () => {
-//   it('is a string', () => {
-//     expect(getRandomString()).toEqual(jasmine.any(String));
-//   });
-// });
+describe('getRandomString', () => {
+  it('is a string', () => {
+    expect(getRandomString()).toEqual(jasmine.any(String));
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/steida/este/issues/137.

Babel v 0.5 moves `require` statements transpired from `import` to the top of the file before the `dontMock` call. Always use `require` for test for now.