### PR TITLE
Always use curly brackets for if/else blocks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,6 @@
     "comma-spacing": [1, {"before": false, "after": true}],
     "comma-style": [1, "last"],
     "consistent-this": [1, "self"],
-    "curly": [2, "multi"],
     "eqeqeq": [2, "allow-null"],
     "eol-last": 1,
     "guard-for-in": 0,

--- a/src/client/auth/actions.js
+++ b/src/client/auth/actions.js
@@ -34,10 +34,11 @@ function validateCredentials(fields) {
   // Simulate long async action.
   return new Promise((resolve, reject) => {
     setTimeout(() => {
-      if (fields.password === 'pass1')
+      if (fields.password === 'pass1') {
         resolve();
-      else
+      } else {
         reject(new ValidationError('Wrong password', 'password'));
+      }
     }, 3000);
   });
 }

--- a/src/client/auth/requireauth.react.js
+++ b/src/client/auth/requireauth.react.js
@@ -7,8 +7,9 @@ export default function auth(Component) {
 
   return class Auth extends React.Component {
     static willTransitionTo(transition) {
-      if (!isLoggedIn())
+      if (!isLoggedIn()) {
         transition.redirect('/login', {}, {nextPath: transition.path});
+      }
     }
     render() {
       return <Component {...this.props} />;

--- a/src/client/dispatcher.js
+++ b/src/client/dispatcher.js
@@ -11,14 +11,16 @@ export function register(callback: Function): string {
 }
 
 export function dispatch(action: Function, data: ?Object, options: ?Object) {
-  if (isDev && action.toString === Function.prototype.toString)
+  if (isDev && action.toString === Function.prototype.toString) {
     throw new Error(`Action ${action} toString method has to be overridden by setToString.`);
+  }
 
   const looksLikePromise = data && typeof data.then === 'function';
-  if (looksLikePromise)
+  if (looksLikePromise) {
     return dispatchAsync(action, data, options);
-  else
+  } else {
     dispatchSync(action, data);
+  }
 }
 
 export function isPending(actionName) {
@@ -28,15 +30,21 @@ export function isPending(actionName) {
 function dispatchAsync(action: Function, promise: Object, options: ?Object) {
   const actionName = action.toString();
   // Pending property is defined lazily.
-  if (!action.hasOwnProperty('pending'))
+  if (!action.hasOwnProperty('pending')) {
     Object.defineProperty(action, 'pending', {
       get: () => isPending(actionName)
     });
+  }
 
-  if (isPending(actionName))
-    if (isDev) console.warn(`Warning: Action ${actionName} is already pending.`);
+  if (isPending(actionName)) {
+    if (isDev) {
+      console.warn(`Warning: Action ${actionName} is already pending.`);
+    }
+  }
 
-  if (isDev) console.log(`pending ${actionName}`);
+  if (isDev) {
+    console.log(`pending ${actionName}`);
+  }
   setPending(actionName, true);
   return promise.then(
     (data) => {
@@ -45,7 +53,9 @@ function dispatchAsync(action: Function, promise: Object, options: ?Object) {
       return data;
     },
     (reason) => {
-      if (isDev) console.log(`reject ${actionName}`);
+      if (isDev) {
+        console.log(`reject ${actionName}`);
+      }
       setPending(actionName, false);
       throw reason;
     }
@@ -60,6 +70,8 @@ function setPending(actionName: string, pending: boolean) {
 }
 
 function dispatchSync(action: Function, data: ?Object) {
-  if (isDev) console.log(action);
+  if (isDev) {
+    console.log(action);
+  }
   dispatcher.dispatch({action, data});
 }

--- a/src/client/intl/store.js
+++ b/src/client/intl/store.js
@@ -7,8 +7,9 @@ const cachedInstances = Object.create(null);
 const intlRelativeFormat = new IntlRelativeFormat;
 
 function getCachedInstanceOf(message) {
-  if (message in cachedInstances)
+  if (message in cachedInstances) {
     return cachedInstances[message];
+  }
   // TODO: Add locales support.
   cachedInstances[message] = new IntlMessageFormat(message);
   return cachedInstances[message];
@@ -17,10 +18,12 @@ function getCachedInstanceOf(message) {
 export function msg(path, values = null): string {
   const pathParts = ['messages'].concat(path.split('.'));
   const message = i18nCursor().getIn(pathParts);
-  if (message == null)
+  if (message == null) {
     throw new ReferenceError('Could not find Intl message: ' + path);
-  if (!values)
+  }
+  if (!values) {
     return message;
+  }
 
   return getCachedInstanceOf(message).format(values);
 }

--- a/src/client/pages/todos.react.js
+++ b/src/client/pages/todos.react.js
@@ -34,7 +34,9 @@ export default class Todos extends React.Component {
 
   onDocumentKeypress(e) {
     // Press shift+ctrl+s to save app state and shift+ctrl+l to load.
-    if (!e.shiftKey || !e.ctrlKey) return;
+    if (!e.shiftKey || !e.ctrlKey) {
+      return;
+    }
     switch (e.keyCode) {
       case 19:
         window._appState = state.save();
@@ -48,7 +50,9 @@ export default class Todos extends React.Component {
       case 12:
         const stateStr = window.prompt('Path the serialized state into the input'); // eslint-disable-line no-alert
         const newState = JSON.parse(stateStr);
-        if (!newState) return;
+        if (!newState) {
+          return;
+        }
         state.load(newState);
         break;
     }
@@ -61,7 +65,9 @@ export default class Todos extends React.Component {
 
   render() {
     // This is just a demo. In real app you would set first undo elsewhere.
-    if (!undoStates.length) undoStates.push(state.get());
+    if (!undoStates.length) {
+      undoStates.push(state.get());
+    }
 
     // This is composite component. It load its data from store, and passes them
     // through props, so NewTodo and TodoList can leverage PureComponent.

--- a/src/client/todos/actions.js
+++ b/src/client/todos/actions.js
@@ -14,7 +14,9 @@ export function onNewTodoFieldChange({target: {name, value}}) {
 
 export function addTodo(todo) {
   const title = todo.get('title').trim();
-  if (!title) return;
+  if (!title) {
+    return;
+  }
   dispatch(addTodo, todo);
 }
 

--- a/src/client/todos/newtodo.react.js
+++ b/src/client/todos/newtodo.react.js
@@ -8,8 +8,9 @@ import {msg} from '../intl/store';
 export default class NewTodo extends PureComponent {
 
   addTodoOnEnter(e) {
-    if (e.key === 'Enter')
+    if (e.key === 'Enter') {
       addTodo(this.props.todo);
+    }
   }
 
   render() {

--- a/src/lib/state.js
+++ b/src/lib/state.js
@@ -18,7 +18,9 @@ export default class State extends EventEmitter {
   }
 
   set(state) {
-    if (this._state === state) return;
+    if (this._state === state) {
+      return;
+    }
     this._state = state;
     this.emit('change', this._state);
   }
@@ -37,10 +39,11 @@ export default class State extends EventEmitter {
 
   cursor(path) {
     return (update) => {
-      if (update)
+      if (update) {
         this.set(this._state.updateIn(path, update));
-      else
+      } else {
         return this._state.getIn(path);
+      }
     };
   }
 

--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -16,11 +16,17 @@ export class ValidationError extends Error {
 export function focusInvalidField(component) {
   return (error) => {
     if (error instanceof ValidationError) {
-      if (!error.prop) return;
+      if (!error.prop) {
+        return;
+      }
       const node = React.findDOMNode(component);
-      if (!node) return;
+      if (!node) {
+        return;
+      }
       const el = node.querySelector(`[name=${error.prop}]`);
-      if (!el) return;
+      if (!el) {
+        return;
+      }
       el.focus();
       return;
     }
@@ -42,7 +48,9 @@ export default class Validation {
     const value = this._object[prop];
     const object = this._object;
     this.promise = this.promise.then(() => {
-      if (required && !this._isEmptyString(value)) return;
+      if (required && !this._isEmptyString(value)) {
+        return;
+      }
       callback(value, prop, object);
     });
     return this;
@@ -72,7 +80,9 @@ export default class Validation {
 
   email() {
     return this.custom((value, prop) => {
-      if (this._validator.isEmail(value)) return;
+      if (this._validator.isEmail(value)) {
+        return;
+      }
       throw new ValidationError(
         this.getEmailMessage(prop, value),
         prop
@@ -87,7 +97,9 @@ export default class Validation {
   simplePassword() {
     return this.custom((value, prop) => {
       const minLength = 5;
-      if (value.length >= minLength) return;
+      if (value.length >= minLength) {
+        return;
+      }
       throw new ValidationError(
         this.getSimplePasswordMessage(minLength),
         prop

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,12 +1,14 @@
 const config = require('./config');
 
 if (config.isProduction || require('piping')(config.piping)) {
-  if (!process.env.NODE_ENV)
+  if (!process.env.NODE_ENV) {
     throw new Error('Environment variable NODE_ENV must be set.');
+  }
 
   // Load and use polyfill for ECMA-402.
-  if (!global.Intl)
+  if (!global.Intl) {
     global.Intl = require('intl');
+  }
 
   require('babel/register');
 

--- a/src/server/render.js
+++ b/src/server/render.js
@@ -70,7 +70,7 @@ function getPageHtml(Handler, appState) {
       })();
     </script>`;
 
-  if (config.isProduction && config.googleAnalyticsId !== 'UA-XXXXXXX-X')
+  if (config.isProduction && config.googleAnalyticsId !== 'UA-XXXXXXX-X') {
     scriptHtml += `
       <script>
         (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
@@ -80,6 +80,7 @@ function getPageHtml(Handler, appState) {
         r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
         ga('create','${config.googleAnalyticsId}');ga('send','pageview');
       </script>`;
+  }
 
   const title = DocumentTitle.rewind();
 

--- a/webpack/build.js
+++ b/webpack/build.js
@@ -11,8 +11,9 @@ module.exports = function(webpackConfig) {
       var jsonStats = stats.toJson();
       var buildError = fatalError || jsonStats.errors[0] || jsonStats.warnings[0];
 
-      if (buildError)
+      if (buildError) {
         throw new gutil.PluginError('webpack', buildError);
+      }
 
       gutil.log('[webpack]', stats.toString({
         colors: true,

--- a/webpack/devserver.js
+++ b/webpack/devserver.js
@@ -28,8 +28,9 @@ module.exports = function(webpackConfig) {
       }
     }).listen(8888, 'localhost', function(err) {
       // Callback is called only once, can't be used to catch compilation errors.
-      if (err)
+      if (err) {
         throw new gutil.PluginError('webpack-dev-server', err);
+      }
       gutil.log('[webpack-dev-server]', 'localhost:8888/build/client.js');
       callback();
     });

--- a/webpack/makeconfig.js
+++ b/webpack/makeconfig.js
@@ -91,14 +91,14 @@ module.exports = function(isDevelopment) {
           }
         })
       ];
-      if (isDevelopment)
+      if (isDevelopment) {
         plugins.push(
           NotifyPlugin,
           new webpack.HotModuleReplacementPlugin(),
           // Tell reloader to not reload if there is an error.
           new webpack.NoErrorsPlugin()
         );
-      else
+      } else {
         plugins.push(
           // Render styles into separate cacheable file to prevent FOUC and
           // optimize for critical rendering path.
@@ -113,6 +113,7 @@ module.exports = function(isDevelopment) {
             }
           })
         );
+      }
       return plugins;
     })(),
     resolve: {

--- a/webpack/notifyplugin.js
+++ b/webpack/notifyplugin.js
@@ -21,15 +21,18 @@ module.exports = function() {
   this.plugin('done', function(stats) {
     // TODO: Handle warnings as well.
     var error = stats.compilation.errors[0];
-    if (!error) return;
+    if (!error) {
+      return;
+    }
     var loc = error.error.loc;
     var msg;
-    if (loc)
+    if (loc) {
       msg = getLocMessage(error, loc);
-    else if (error.message)
+    } else if (error.message) {
       msg = error.message;
-    else
+    } else {
       return;
+    }
 
     notifier.notify({
       title: 'Webpack Error',


### PR DESCRIPTION
`"curly": [2, "multi"]` rule removed, so the standard (common) way of using curly brackets for if blocks is enforced.

You always have to use this syntax (wasn't possible with the `"curly": [2, "multi"]`):
```
if (foo) {
  boo();
}
```

This throws a warning now: 
```
if (foo)
  boo();

if (foo) boo();
```