### PR TITLE
Better custom state

### DIFF
--- a/src/server/frontend/index.js
+++ b/src/server/frontend/index.js
@@ -1,6 +1,7 @@
 import compression from 'compression';
 import express from 'express';
 // import favicon from 'serve-favicon';
+import config from '../config';
 import render from './render';
 
 const app = express();
@@ -12,8 +13,27 @@ app.use(compression());
 app.use('/build', express.static('build'));
 app.use('/assets', express.static('assets'));
 
+// Example how initialState, which is the same for all users, is enriched with
+// user state. With state-less Flux, we don't need instances.
+app.use(function(req, res, next) {
+
+  const acceptsLanguages = req.acceptsLanguages(config.appLocales);
+
+  req.userState = {
+    i18n: {
+      locales: acceptsLanguages || config.defaultLocale
+    }
+  };
+
+  // Simulate async loading from DB.
+  setTimeout(() => {
+    next();
+  }, 20);
+
+});
+
 app.get('*', (req, res, next) => {
-  render(req, res).catch(next);
+  render(req, res, req.userState).catch(next);
 });
 
 app.on('mount', () => {

--- a/src/server/frontend/render.js
+++ b/src/server/frontend/render.js
@@ -9,31 +9,9 @@ import initialState from '../initialstate';
 import routes from '../../client/routes';
 import {state} from '../../client/state';
 
-export default function render(req, res) {
-  return loadUserState(req)
-    .then((appState) => {
-      return renderPage(req, res, appState);
-    });
-}
-
-// Example how initialState, which is the same for all users, is enriched with
-// user state. With state-less Flux, we don't need instances.
-function loadUserState(req) {
-  return new Promise((resolve, reject) => {
-
-    const acceptsLanguages = req.acceptsLanguages(config.appLocales);
-    const userState = {
-      i18n: {
-        locales: acceptsLanguages || config.defaultLocale
-      }
-    };
-    const appState = Immutable.fromJS(initialState).mergeDeep(userState).toJS();
-
-    // Simulate async loading from DB.
-    setTimeout(() => {
-      resolve(appState);
-    }, 20);
-  });
+export default function render(req, res, userState = {}) {
+  const appState = Immutable.fromJS(initialState).mergeDeep(userState).toJS();
+  return renderPage(req, res, appState);
 }
 
 function renderPage(req, res, appState) {


### PR DESCRIPTION
This pull request simulates more real-life example by adding a general-purpose middleware that acts almost like e.g. https://www.npmjs.com/package/express-jwt.

Instead of having custom state logic hardcoded inside `render` which should just render files, we now fetch user details in a way every other project already does. That is, it's going to be easier for our users to understand the purpose as they are already familiar with this pattern.