### PR TITLE
Output standardization of msgs function

### DIFF
--- a/src/client/intl/store.js
+++ b/src/client/intl/store.js
@@ -39,10 +39,10 @@ export function msgs(path, values = null, ...sliceParams): List<Map> {
 
   const messageList = !sliceParams ? messages : List.prototype.slice.apply(messages, sliceParams);
 
-  return !values ? messageList : messageList.map((item) => Map({
-      key: item.get('key'),
+  return !values ? messageList : messageList.map((item) =>
+    item.merge(Map({
       txt: getCachedInstanceOf(item.get('txt')).format(values)
-    }));
+    })));
 }
 
 export function relativeDateFormat(date, options?): string {


### PR DESCRIPTION
I standardized the output of msgs function to always return all keys defined in the Map for one List item. It solves step 3 in #246 