### PR TITLE
Localhost replaced by 0.0.0.0, then the dev mode works even from remote machines.

### DIFF
--- a/webpack/devserver.js
+++ b/webpack/devserver.js
@@ -26,6 +26,8 @@ module.exports = function(webpackConfig) {
         chunks: false,
         chunkModules: false
       }
+    // Why '0.0.0.0' and 'localhost'? Because it works for remote machines.
+    // https://github.com/webpack/webpack-dev-server/issues/151#issuecomment-104643642
     }).listen(8888, '0.0.0.0', function(err) {
       // Callback is called only once, can't be used to catch compilation errors.
       if (err)

--- a/webpack/devserver.js
+++ b/webpack/devserver.js
@@ -26,7 +26,7 @@ module.exports = function(webpackConfig) {
         chunks: false,
         chunkModules: false
       }
-    }).listen(8888, 'localhost', function(err) {
+    }).listen(8888, '0.0.0.0', function(err) {
       // Callback is called only once, can't be used to catch compilation errors.
       if (err)
         throw new gutil.PluginError('webpack-dev-server', err);


### PR DESCRIPTION
More info: https://github.com/webpack/webpack-dev-server/issues/151#issuecomment-104643642

With host = localhost is not possible to access webpack-dev-server from remote machines. With `0.0.0.0` you can just change the `localhost:8888` in `<script></script>`  to `NETWORK_ADDRESS:8888` and it works (without hot reloading though).